### PR TITLE
Statisk path for resurser

### DIFF
--- a/ukmkalender.php
+++ b/ukmkalender.php
@@ -41,7 +41,7 @@ function UKMkalender_script() {
 	wp_enqueue_script('WPbootstrap3_js');
 	wp_enqueue_style('WPbootstrap3_css');
 #	wp_enqueue_style( 'UKMkalender_style', plugin_dir_url( __FILE__ ) .'ukmvideresending_festival.css');
-	wp_enqueue_script( 'UKMKalender_script', plugin_dir_url( __FILE__ ) .'ukmkalender.js');
+	wp_enqueue_script( 'UKMKalender_script', PLUGIN_PATH .'UKMkalender/ukmkalender.js');
 }
 
 function UKMkalender_dash( $KALENDER ) {


### PR DESCRIPTION
Bruker en final variable for å definere statisk path-en for å peke på resurser.

Deriverer fra: https://github.com/UKMNorge/UKMresources/issues/3

OBS: UKMconfig.inc.php er modifisert. Denne linjen er lagt til
"# RESOURCES PLUGIN PATH
define('PLUGIN_PATH', 'https://' . UKM_HOSTNAME . '/wp-content/plugins/');"